### PR TITLE
chore: fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Microsoft",
   "license": "MIT",
   "main": "./dist/index.js",
-  "module": "./dist/globe.ems.js",
+  "module": "./dist/globe.esm.js",
   "typings": "./dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14183168/74138529-0bc74900-4bf2-11ea-9130-678541c61230.png)

This PR fixes a small typo in `module` property in `package.json`.