### PR TITLE
Add support for HOUR_ONLY with OS format strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ NPM Releases are made manually by @TomasHubelbauer at the moment.
 
 ## Release Notes
 
+### `2.7.0` 2020-05-14
+
+We've added preliminary handling for AM/PM (day period) format which
+supports the `HOUR_ONLY` option when using the OS date and time format strings.
+The supported OSs (macOS and Windows) do not expose a dedicated format string
+for an hour-only scenario, so we detect whether the OS format string for
+short date includes the AM/PM format string token and constuct a makeshift
+`HOUR_ONLY` format string for that case which either also includes AM/PM or
+doesn't depending on if the original short time format string did.
+
 ### `2.6.0` 2020-05-04
 
 We've switched to a single-level cache between the pair made up by the locale

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ NPM Releases are made manually by @TomasHubelbauer at the moment.
 
 ## Release Notes
 
-### `2.7.0` 2020-05-14
+### `2.6.1` 2020-05-14
 
 We've added preliminary handling for AM/PM (day period) format which
 supports the `HOUR_ONLY` option when using the OS date and time format strings.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/globe",
-  "version": "2.7.0",
+  "version": "2.6.1",
   "description": "Globalization Service",
   "author": "Microsoft",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/globe",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Globalization Service",
   "author": "Microsoft",
   "license": "MIT",

--- a/src/date-time-format-options.ts
+++ b/src/date-time-format-options.ts
@@ -54,15 +54,15 @@ type FullDate = Readonly<{
   month: 'long'
 }>;
 
-type MediumTime = Readonly<{ 
-  hour: 'numeric', 
-  minute: 'numeric', 
+type MediumTime = Readonly<{
+  hour: 'numeric',
+  minute: 'numeric',
   second: 'numeric'
 }>;
 
-type MediumDate = Readonly<{ 
-  day: 'numeric', 
-  month: 'short' 
+type MediumDate = Readonly<{
+  day: 'numeric',
+  month: 'short'
 }>;
 
 type MediumDateWithYear = Readonly<{
@@ -79,7 +79,7 @@ type LongWeekday = Readonly<{ weekday: 'long' }>;
 
 type ShortWeekday = Readonly<{ weekday: 'short' }>;
 
-type HourOnly = Readonly<{ hour: 'numeric'}>;
+type HourOnly = Readonly<{ hour: 'numeric' }>;
 
 export type TimeStringFormat = 'numeric' | '2-digit';
 
@@ -161,15 +161,15 @@ export const FULL_DATE: FullDate = {
   month: 'long'
 };
 
-export const MEDIUM_TIME: MediumTime = { 
-  hour: 'numeric', 
-  minute: 'numeric', 
+export const MEDIUM_TIME: MediumTime = {
+  hour: 'numeric',
+  minute: 'numeric',
   second: 'numeric'
 };
 
-export const MEDIUM_DATE: MediumDate = { 
-  day: 'numeric', 
-  month: 'short' 
+export const MEDIUM_DATE: MediumDate = {
+  day: 'numeric',
+  month: 'short'
 };
 
 export const MEDIUM_DATE_WITH_YEAR: MediumDateWithYear = {

--- a/src/date-time-formatter.test.ts
+++ b/src/date-time-formatter.test.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-const { DateTimeFormatter, LONG_DATE } = require('../dist/globe.cjs.development');
+const { DateTimeFormatter, LONG_DATE, HOUR_ONLY } = require('../dist/globe.cjs.development');
 
 describe('date-time-format-options', () => {
   it('constructs without throwing', () => {
@@ -28,5 +28,19 @@ describe('date-time-format-options', () => {
     const dateTimeFormatter = new DateTimeFormatter(localeInfo);
     const date = new Date(2020, 1, 1, 12, 0, 0);
     expect(dateTimeFormatter.formatDateTime(date, LONG_DATE)).toBe('1 February 2020');
+  });
+
+  it('uses mac 12 hour format', () => {
+    const localeInfo = { platform: 'macos', regionalFormat: 'en-US', shortTime: 'h:mm a' };
+    const dateTimeFormatter = new DateTimeFormatter(localeInfo);
+    const date = new Date(2020, 1, 1, 15, 0, 0);
+    expect(dateTimeFormatter.formatDateTime(date, HOUR_ONLY)).toBe('3 PM');
+  });
+
+  it('uses mac 24 hour format', () => {
+    const localeInfo = { platform: 'macos', regionalFormat: 'en-US', shortTime: 'HH:mm' };
+    const dateTimeFormatter = new DateTimeFormatter(localeInfo);
+    const date = new Date(2020, 1, 1, 15, 0, 0);
+    expect(dateTimeFormatter.formatDateTime(date, HOUR_ONLY)).toBe('15');
   });
 });

--- a/src/date-time-formatter.ts
+++ b/src/date-time-formatter.ts
@@ -254,6 +254,10 @@ export class DateTimeFormatter {
 
     switch (format) {
       case SHORT_TIME: {
+        if (!localeInfo.shortTime) {
+          throw new Error(`localeInfo.shortTime was not provided!`);
+        }
+
         if (localeInfo.platform === 'macos') {
           return this.macTimeToString(date, localeInfo.shortTime);
         } else {
@@ -263,6 +267,10 @@ export class DateTimeFormatter {
       case SHORT_DATE:
       case SHORT_DATE_WITH_SHORT_YEAR:
       case SHORT_DATE_WITH_YEAR: {
+        if (!localeInfo.shortDate) {
+          throw new Error(`localeInfo.shortDate was not provided!`);
+        }
+
         if (localeInfo.platform === 'macos') {
           return this.macDateToString(date, localeInfo.shortDate);
         } else {
@@ -270,15 +278,36 @@ export class DateTimeFormatter {
         }
       }
       case SHORT_DATE_TIME: {
+        if (!localeInfo.shortDate || !localeInfo.shortTime) {
+          throw new Error(`localeInfo.shortDate or localeInfo.shortTime was not provided!`);
+        }
+
         if (localeInfo.platform === 'macos') {
           return `${this.macDateToString(date, localeInfo.shortDate)} ${this.macTimeToString(date, localeInfo.shortTime)}`;
         } else {
           return `${this.windowsDateToString(date, localeInfo.shortDate)} ${this.windowsTimeToString(date, localeInfo.shortTime)}`;
         }
       }
-      case HOUR_ONLY:
+      case HOUR_ONLY: {
+        if (!localeInfo.shortTime) {
+          throw new Error(`localeInfo.shortTime was not provided!`);
+        }
+
+        if (localeInfo.platform === 'macos') {
+          const includesADayPeriod = localeInfo.shortTime.includes('a');
+          return this.macTimeToString(date, includesADayPeriod ? 'h a' : 'H');
+        } else {
+          const includesTTDayPeriod = localeInfo.shortTime.includes('tt');
+          const includesTDayPeriod = localeInfo.shortTime.includes('tt');
+          return this.macTimeToString(date, includesTTDayPeriod ? 'h tt' : (includesTDayPeriod ? 'h t' : 'H'));
+        }
+      }
       case MEDIUM_TIME:
       case LONG_TIME: {
+        if (!localeInfo.longTime) {
+          throw new Error(`localeInfo.longTime was not provided!`);
+        }
+
         if (localeInfo.platform === 'macos') {
           return this.macTimeToString(date, localeInfo.longTime);
         } else {
@@ -287,6 +316,10 @@ export class DateTimeFormatter {
       }
       case MEDIUM:
       case MEDIUM_WITH_YEAR: {
+        if (!localeInfo.longDate || !localeInfo.longTime) {
+          throw new Error(`localeInfo.longDate or localeInfo.longTime was not provided!`);
+        }
+
         if (localeInfo.platform === 'macos') {
           return `${this.macDateToString(date, localeInfo.longDate)} ${this.macTimeToString(date, localeInfo.longTime)}`;
         } else {
@@ -299,6 +332,10 @@ export class DateTimeFormatter {
       case MEDIUM_DATE_WITH_YEAR:
       case LONG_DATE_WITH_YEAR:
       case FULL_DATE_WITH_YEAR: {
+        if (!localeInfo.longDate) {
+          throw new Error(`localeInfo.longDate was not provided!`);
+        }
+
         if (localeInfo.platform === 'macos') {
           return this.macDateToString(date, localeInfo.longDate);
         } else {


### PR DESCRIPTION
From the changelog:

> We've added preliminary handling for AM/PM (day period) format which
supports the `HOUR_ONLY` option when using the OS date and time format strings.
The supported OSs (macOS and Windows) do not expose a dedicated format string
for an hour-only scenario, so we detect whether the OS format string for
short date includes the AM/PM format string token and constuct a makeshift
`HOUR_ONLY` format string for that case which either also includes AM/PM or
doesn't depending on if the original short time format string did.