### PR TITLE
Performance: do not use for...of

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ NPM Releases are made manually by @TomasHubelbauer at the moment.
 
 ## Release Notes
 
+### `2.7.4` 2020-06-29
+
+Do not use `for...of` because of perf impact.
+
 ### `2.7.3` 2020-06-16
 
 Improved performance, by adding more caching.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "clean": "rimraf dist",
     "tslint": "tslint --project tsconfig.json -r tslint.json -r ./node_modules/tslint-microsoft-contrib --fix || true",
     "prepare": "npm run build",
-    "test": "jest"
+    "test": "jest",
+    "test:debug": "node --inspect node_modules/.bin/jest --watch --runInBand"
   },
   "devDependencies": {
     "@types/jest": "^25.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/globe",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Globalization Service",
   "author": "Microsoft",
   "license": "MIT",

--- a/src/date-time-formatter.test.ts
+++ b/src/date-time-formatter.test.ts
@@ -147,4 +147,28 @@ describe('date-time-format-options', () => {
       expect(dateTimeFormatter.formatDateTime(date, SHORT_WEEKDAY_LONG_TIME)).toBe('Sun, 3:40:25 PM');
     });
   });
+
+  xdescribe('performance', () => {
+    const localeInfo = {
+      platform: 'windows',
+      regionalFormat: 'en-US',
+      shortDate: 'M/d/yyyy',
+      longDate: 'dddd, MMMM d, yyyy',
+      shortTime: 'h:mm tt',
+      longTime: 'h:mm:ss tt',
+    };
+
+    it('is fast', () => {      
+      const dateTimeFormatter = new DateTimeFormatter(localeInfo);
+      const date = new Date(2020, 5, 28, 15, 40, 25);
+      let result = '';
+      const start = performance.now();
+      for (let i = 0; i < 1000; i++) {
+        result = dateTimeFormatter.formatDateTime(date, SHORT_DATE_TIME);
+      }
+      const end = performance.now();
+      expect(result).toBe('6/28/2020 3:40 PM');
+      expect(end - start).toBe(0);
+    });
+  });
 });

--- a/src/date-time-formatter.ts
+++ b/src/date-time-formatter.ts
@@ -77,7 +77,7 @@ export class DateTimeFormatter {
   }
 
   private cachedDateTimeFormat(locale: string, dateTimeOptions: Intl.DateTimeFormatOptions) {
-    const key = JSON.stringify({ locale, dateTimeOptions });
+    const key = `${locale}:${JSON.stringify(dateTimeOptions)}`;
     let dtf = this.localeFormatCache.get(key);
     if (!dtf) {
       dtf = Intl.DateTimeFormat(locale, dateTimeOptions);


### PR DESCRIPTION
According to the profiles, TS code around constructing for...of loop was among the function where the time was spent most.

This PR replaces it with `array.every()`: https://caniuse.com/#search=every

Locally, time for formatting 1000 dates reduced from arond 270ms to around 160ms.