### PR TITLE
safe datetime format, use 0 for midnight instead of 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ NPM Releases are made manually by @TomasHubelbauer at the moment.
 
 ## Release Notes
 
+### `2.8.1` 2020-07-20
+SafeDateTimeFormat with fallback to UTC if timezone is not detected or provided
+Use 0 instead of 24 for H and HH tokens
+
 ### `2.8.0` 2020-06-29
 
 Precompute formats so that applying is faster.

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
   <script>
     var exports = {};
   </script>
-  <script src="https://unpkg.com/@microsoft/globe@2.8.0/dist/globe.cjs.development.js"></script>
+  <script src="https://unpkg.com/@microsoft/globe@2.8.1/dist/globe.cjs.development.js"></script>
   <style>
     .header {
       display: flex;

--- a/docs/time.html
+++ b/docs/time.html
@@ -5,7 +5,7 @@
   <script>
     var exports = {};
   </script>
-  <script src="https://unpkg.com/@microsoft/globe@2.8.0/dist/globe.cjs.development.js"></script>
+  <script src="https://unpkg.com/@microsoft/globe@2.8.1/dist/globe.cjs.development.js"></script>
   <style>
     .header {
       display: flex;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/globe",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Globalization Service",
   "author": "Microsoft",
   "license": "MIT",

--- a/src/cached-datetimeformat.ts
+++ b/src/cached-datetimeformat.ts
@@ -3,17 +3,19 @@
  * Licensed under the MIT License.
  */
 
+import { SafeDateTimeFormat } from './safe-datetimeformat';
+
 export class CachedDateTimeFormat {
   // We're keying this using JSON.stringify because with a WeakMap we've have a key pair
   // (locale - string & options - object) and stringify is native so it is so fars it is
   // not worth maintaing the two-level cache (map for string and weak map for object)
-  private readonly localeFormatCache = new Map<string, Intl.DateTimeFormat>();
+  private readonly localeFormatCache = new Map<string, SafeDateTimeFormat>();
 
   public get(locale: string, dateTimeOptions: Intl.DateTimeFormatOptions) {
     const key = `${locale}:${JSON.stringify(dateTimeOptions)}`;
     let dtf = this.localeFormatCache.get(key);
     if (!dtf) {
-      dtf = Intl.DateTimeFormat(locale, dateTimeOptions);
+      dtf = new SafeDateTimeFormat(locale, dateTimeOptions);
       this.localeFormatCache.set(key, dtf);
     }
 

--- a/src/date-time-formatter.test.ts
+++ b/src/date-time-formatter.test.ts
@@ -19,7 +19,8 @@ const {
   FULL_WITH_YEAR,
   FULL,
   SHORT_WITH_YEAR,
-  SHORT
+  SHORT,
+  SHORT_TIME
 } = require('../dist/globe.cjs.development');
 
 describe('date-time-format-options', () => {
@@ -241,6 +242,18 @@ describe('date-time-format-options', () => {
         expect(dateTimeFormatter.formatDateTime(date, LONG_DATE)).toBe('1-Saturday, 2-February 1, 20-2020');
       });
 
+      it('Uses 0 for midnight', () => {
+        const localeInfo = {
+          platform: 'windows',
+          regionalFormat: 'en-us',
+          shortTime: 'H:mm',
+        };
+    
+        const dateTimeFormatter = new DateTimeFormatter(localeInfo);
+        const date = new Date(2020, 1, 1, 0, 15, 30);
+        expect(dateTimeFormatter.formatDateTime(date, SHORT_TIME)).toBe('0:15');
+      });
+
       it('long time with time zone', () => {
         const dateTimeFormatter = new DateTimeFormatter(localeInfo);
         const date = new Date(2020, 5, 28, 15, 40, 25);
@@ -282,30 +295,6 @@ describe('date-time-format-options', () => {
         const result = dateTimeFormatter.formatDateTime(date, SHORT_DATE_TIME);
         expect(result).toBe('6/28/2020 3:40 PM');
       });
-    });
-  });
-
-  xdescribe('performance', () => {
-    const localeInfo = {
-      platform: 'windows',
-      regionalFormat: 'en-US',
-      shortDate: 'M/d/yyyy',
-      longDate: 'dddd, MMMM d, yyyy',
-      shortTime: 'h:mm tt',
-      longTime: 'h:mm:ss tt',
-    };
-
-    it('is fast', () => {      
-      const dateTimeFormatter = new DateTimeFormatter(localeInfo);
-      const date = new Date(2020, 5, 28, 15, 40, 25);
-      let result = '';
-      const start = performance.now();
-      for (let i = 0; i < 1000; i++) {
-        result = dateTimeFormatter.formatDateTime(date, SHORT_DATE_TIME);
-      }
-      const end = performance.now();
-      expect(result).toBe('6/28/2020 3:40 PM');
-      expect(end - start).toBe(0);
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,3 +47,5 @@ export {
 } from './os-date-time-formatter';
 
 export { DateTimeFormatter } from './date-time-formatter';
+
+export { SafeDateTimeFormat } from './safe-datetimeformat';

--- a/src/safe-datetimeformat.ts
+++ b/src/safe-datetimeformat.ts
@@ -1,0 +1,56 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+/**
+ * Intl.DateTimeFormat can throw an exception when it does not detect time zone
+ * If time zone is not specified, use fallback to UTC instead of throwing an exception
+ */
+export class SafeDateTimeFormat {
+  private static _fallbackNeeded: boolean | undefined = undefined;
+  private static fallbackNeeded = (locales?: string | string[] | undefined) => {
+    if (SafeDateTimeFormat._fallbackNeeded === undefined) {
+      const format = Intl.DateTimeFormat(locales);
+      const tz = format.resolvedOptions().timeZone;
+      if (!tz || tz.toLowerCase() === 'etc/unknown') {
+        SafeDateTimeFormat._fallbackNeeded = true;
+      } else {
+        SafeDateTimeFormat._fallbackNeeded = false;
+      }
+    }
+
+    return SafeDateTimeFormat._fallbackNeeded;
+  }
+
+  private _format: Intl.DateTimeFormat;
+
+  private getOptionsWithFallback(locales?: string | string[] | undefined, options?: Intl.DateTimeFormatOptions) {
+    if (options && options['timeZone']) {
+      return options;
+    }
+
+    const fallbackNeeded = SafeDateTimeFormat.fallbackNeeded(locales);
+    if (!fallbackNeeded) {
+      return options;
+    }
+
+    return {
+      ...options,
+      timeZone: 'UTC'
+    };
+  }
+
+  constructor(locales?: string | string[] | undefined, options?: Intl.DateTimeFormatOptions) {
+    const optionsWithFallback = this.getOptionsWithFallback(locales, options);
+    this._format = Intl.DateTimeFormat(locales, optionsWithFallback);
+  }
+
+  public format(date?: number | Date | undefined): string {
+    return this._format.format(date);
+  }
+
+  public formatToParts(date?: number | Date | undefined): Intl.DateTimeFormatPart[] {
+    return this._format.formatToParts(date);
+  }
+}


### PR DESCRIPTION
SafeDateTimeFormat with fallback to UTC if timezone is not detected or provided
Use 0 instead of 24 for H and HH tokens