### PR TITLE
Add getLocaleInfoAsync to module exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ NPM Releases are made manually by @TomasHubelbauer at the moment.
 
 ## Release Notes
 
+### `3.1.0` 2020-09-08
+Add getLocaleInfoAsync to module export
+
 ### `3.0.1` 2020-09-04
 Improve error logging for unknown formats
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/globe",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Globalization Service",
   "author": "Microsoft",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,4 +50,4 @@ export { DateTimeFormatter } from './date-time-formatter';
 
 export { SafeDateTimeFormat } from './safe-datetimeformat';
 
-export { getLocaleInfoAsync } from './getLocaleInfoAsync';
+export getLocaleInfoAsync from './getLocaleInfoAsync';

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,3 +49,5 @@ export {
 export { DateTimeFormatter } from './date-time-formatter';
 
 export { SafeDateTimeFormat } from './safe-datetimeformat';
+
+export { getLocaleInfoAsync } from './getLocaleInfoAsync';


### PR DESCRIPTION
It appears that the `getLocaleInfoAsync()` function is not exported by the module and thus cannot properly be imported as shown in the following example taken from the README:

``` typescript
import { getLocaleInfoAsync } from '@microsoft/globe';
// Provide the supported platform name and obtain the OS locale settings
const localeInfo = await getLocaleInfoAsync(/* 'windows` | 'macos' */);
new DateTimeFormatter(localeInfo);
```

This PR is just a quick  one-line change to add this function to the package exports.