### PR TITLE
Fix for Electron bugs with VDI

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ NPM Releases are made manually by @TomasHubelbauer at the moment.
 
 ## Release Notes
 
+### `4.1.3` 2021-08-09
+Attempting to fix VDI issues on Electron
 ### `4.1.2` 2021-03-31
 Fixed 12 hours format for Windows
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
   <script>
     var exports = {};
   </script>
-  <script src="https://unpkg.com/@microsoft/globe@4.1.2/dist/globe.cjs.development.js"></script>
+  <script src="https://unpkg.com/@microsoft/globe@4.1.3/dist/globe.cjs.development.js"></script>
   <!-- <script src="./../dist/globe.cjs.development.js"></script> -->
   <style>
     .header {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/globe",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Globalization Service",
   "author": "Microsoft",
   "license": "MIT",

--- a/src/safe-datetimeformat.test.ts
+++ b/src/safe-datetimeformat.test.ts
@@ -1,0 +1,104 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { getVdiTimeZoneFix } from './safe-datetimeformat';
+
+describe('safe-datetimeformat', () => {
+
+    const nowDate = new Date();
+
+    describe('vdi', () => {
+
+        it('constructs without throwing', () => {
+            getVdiTimeZoneFix();
+        });
+
+        it('If no offset return GMT', () => {
+            const mockDate = new Date();
+            mockDate.getTimezoneOffset = jest.fn().mockReturnValue(0);
+            const spy = jest.spyOn(global, 'Date').mockImplementation(
+                () => (mockDate as unknown) as string);
+
+            try {
+                const tz = getVdiTimeZoneFix();
+                expect(tz).toEqual('Etc/GMT');
+
+                Intl.DateTimeFormat('en-GB', {
+                    timeZone: tz
+                }).format(nowDate);
+            } catch (e) {
+                fail(e);
+            } finally {
+                spy.mockRestore();
+            }
+        });
+
+        it('If unexpected value return UTC', () => {
+
+            const mockDate = new Date();
+            mockDate.getTimezoneOffset = jest.fn().mockReturnValue(13);
+            const spy = jest.spyOn(global, 'Date').mockImplementation(
+                () => (mockDate as unknown) as string);
+
+            try {
+
+                const tz = getVdiTimeZoneFix();
+                expect(tz).toEqual('UTC');
+
+                Intl.DateTimeFormat('en-GB', {
+                    timeZone: tz
+                }).format(nowDate);
+            } catch (e) {
+                fail(e);
+            } finally {
+                spy.mockRestore();
+            }
+        });
+
+        it('If negative hour returns correct format', () => {
+
+            const mockDate = new Date();
+            mockDate.getTimezoneOffset = jest.fn().mockReturnValue(-120);
+            const spy = jest.spyOn(global, 'Date').mockImplementation(
+                () => (mockDate as unknown) as string);
+
+            try {
+                const tz = getVdiTimeZoneFix();
+                expect(tz).toEqual('Etc/GMT-2');
+
+                Intl.DateTimeFormat('en-GB', {
+                    timeZone: tz
+                }).format(nowDate);
+            } catch (e) {
+                fail(e);
+            } finally {
+                spy.mockRestore();
+            }
+        });
+
+        it('If positive hour returns correct format', () => {
+
+            const mockDate = new Date();
+            mockDate.getTimezoneOffset = jest.fn().mockReturnValue(360);
+            const spy = jest.spyOn(global, 'Date').mockImplementation(
+                () => (mockDate as unknown) as string);
+
+            try {
+
+                const tz = getVdiTimeZoneFix();
+                expect(tz).toEqual('Etc/GMT+6');
+
+                Intl.DateTimeFormat('en-GB', {
+                    timeZone: tz
+                }).format(nowDate);
+            } catch (e) {
+                fail(e);
+            } finally {
+                spy.mockRestore();
+            }
+        });
+
+    });
+});

--- a/src/safe-datetimeformat.ts
+++ b/src/safe-datetimeformat.ts
@@ -31,6 +31,21 @@ const checkFallback = (locales?: string | string[] | undefined) => {
   return false;
 };
 
+export function getVdiTimeZoneFix()  {
+  const offset: number = new Date().getTimezoneOffset();
+  if (offset % 60 === 0) {
+    const tz: number = offset / 60;
+    if (tz === 0) {
+      return 'Etc/GMT';
+    } 
+    if (tz > 0) {
+      return "Etc/GMT+" + tz;
+    }
+    return "Etc/GMT"+ tz;
+  }
+  return 'UTC';
+}
+
 const getOptionsWithFallback = (locales?: string | string[] | undefined, options?: Intl.DateTimeFormatOptions) => {
   if (options && options['timeZone']) {
     return options;
@@ -42,7 +57,7 @@ const getOptionsWithFallback = (locales?: string | string[] | undefined, options
 
   return {
     ...options,
-    timeZone: 'UTC'
+    timeZone:  getVdiTimeZoneFix()
   };
 };
 


### PR DESCRIPTION
Fix is for strange Electron bug on VDI environment when Intl.DateTimeFormat doesn't function properly.  Happens from Electron 6-11 we believe.

This is not full fix, but should cover the majority of cases.  We needed can easily be extended to cover other time offsets (i.e. 30 min).

