### PR TITLE
Skip Windows Regional Formats tests

### DIFF
--- a/src/windows-regional-formats.test.ts
+++ b/src/windows-regional-formats.test.ts
@@ -41,7 +41,7 @@ import {
 import { DateTimeFormatter } from "./date-time-formatter";
 import { RegionalSettingsPerLocale } from "./windows-regional-formats";
 
-describe("Windows Regional Formats", () => {
+describe.skip("Windows Regional Formats", () => {
   const supportedLocales = [
     "ar-sa",
     "az-latn-az",


### PR DESCRIPTION
Marking the windows regional formats tests as skipped.
The Intl API's inconsistent support across environments can cause the snapshot tests to fail unpredictably, leading to flaky test results.
These tests are better suited for local validation rather than being part of the automated pipeline.
![image](https://github.com/user-attachments/assets/805b20af-b741-4713-95bb-cc8049cb5cf6)
