### PR TITLE
Enhance release process by adding version check logic and updating RE…

### DIFF
--- a/.azure-devops/globe-release.yml
+++ b/.azure-devops/globe-release.yml
@@ -15,6 +15,9 @@ variables:
     value: production,externalfacing
   - name: serviceTreeID
     value: c3a0680e-4563-4c47-bce9-710df6e5485c
+  # Set to 'true' to skip version check and always try to publish
+  - name: Release.SkipVersionCheck
+    value: false
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
@@ -51,19 +54,44 @@ extends:
                   yarn ci
                 displayName: "Build package and run tests"
 
-              # 2. Git configuration
+              # 2. Check if version has been bumped (git-based)
               - script: |
-                  git config user.email "teams-globalization@microsoft.com"
-                  git config user.name "Globalization Team Account"
-                displayName: "Configure git for release"
+                  set -e
 
-              # 3. Version bump with Beachball
-              - script: yarn bump -y
-                displayName: "Bump version with Beachball"
+                  # Check if version check should be skipped
+                  if [ "$(Release.SkipVersionCheck)" = "true" ]; then
+                    echo "⚠️ Version check is disabled via Release.SkipVersionCheck variable"
+                    echo "##vso[task.logissue type=warning]Skipping version check - SHOULD_PUBLISH will be set to true"
+                    echo "##vso[task.setvariable variable=SHOULD_PUBLISH]true"
+                    echo "shouldPublish=true (version check skipped)"
+                  else
+                    echo "Performing version check..."
+                    git fetch --no-tags --depth=2 origin $(Build.SourceBranchName)
+                    # Compare last commit vs its parent
+                    BEFORE=$(git show $(Build.SourceVersion)^:package.json | node -e "console.log(JSON.parse(require('fs').readFileSync(0,'utf8')).version)")
+                    AFTER=$(node -p "require('./package.json').version")
+
+                    SHOULD_PUBLISH=false
+                    if [ "$BEFORE" != "$AFTER" ]; then
+                      SHOULD_PUBLISH=true
+                    fi
+
+                    echo "From $BEFORE -> $AFTER ; shouldPublish=$SHOULD_PUBLISH"
+                    echo "##vso[task.setvariable variable=SHOULD_PUBLISH]$SHOULD_PUBLISH"
+
+                    # Friendly logging
+                    if [ "$SHOULD_PUBLISH" = "true" ]; then
+                      echo "##vso[task.logissue type=success]✅ Version bumped from $BEFORE to $AFTER. Proceeding with release."
+                    else
+                      echo "##vso[task.logissue type=warning]⚠️ No version change detected ($BEFORE). Skipping release steps."
+                    fi
+                  fi
+                displayName: "Package version check"
 
               # 4. Publish build artifacts
               - task: 1ES.PublishPipelineArtifact@1
                 displayName: "Publish built package"
+                condition: and(succeeded(), eq(variables['SHOULD_PUBLISH'], 'true'))
                 inputs:
                   artifactName: package-$(Build.BuildNumber)
                   targetPath: $(System.DefaultWorkingDirectory)/dist
@@ -71,7 +99,7 @@ extends:
               # 5. ESRP Code signing
               - task: EsrpCodeSigning@5
                 displayName: "ESRP Code Signing"
-                condition: succeeded()
+                condition: and(succeeded(), eq(variables['SHOULD_PUBLISH'], 'true'))
                 inputs:
                   ConnectedServiceName: $(CodeSign.ConnectedServiceName)
                   FolderPath: $(System.DefaultWorkingDirectory)/dist
@@ -101,11 +129,12 @@ extends:
                   mkdir -p $(System.DefaultWorkingDirectory)/packages
                   npm pack --pack-destination $(System.DefaultWorkingDirectory)/packages
                 displayName: "Generate npm package (.tgz)"
+                condition: and(succeeded(), eq(variables['SHOULD_PUBLISH'], 'true'))
 
               # 7. ESRP Release
               - task: EsrpRelease@9
                 displayName: "ESRP Release to npm"
-                condition: succeeded()
+                condition: and(succeeded(), eq(variables['SHOULD_PUBLISH'], 'true'))
                 inputs:
                   connectedservicename: $(Release.ConnectedServiceName)
                   usemanagedidentity: true
@@ -122,6 +151,19 @@ extends:
               # 8. SBOM generation
               - task: 1ES.PublishPipelineArtifact@1
                 displayName: 📒 Publish Manifest
+                condition: and(succeeded(), eq(variables['SHOULD_PUBLISH'], 'true'))
                 inputs:
                   artifactName: SBom-$(System.JobAttempt)
                   targetPath: $(System.DefaultWorkingDirectory)/_manifest
+
+              # 9. Skip message
+              - script: |
+                  echo "##[section]🔄 No version bump detected"
+                  echo "##[warning]The package version has not been bumped since the last release."
+                  echo "##[warning]To publish a new version:"
+                  echo "##[warning]1. Run 'yarn change' to create a change file"
+                  echo "##[warning]2. Run 'yarn bump' to bump the version"
+                  echo "##[warning]3. Commit and push the changes"
+                  echo "##[warning]4. Re-run this pipeline"
+                displayName: "Version not bumped - Skip publishing"
+                condition: and(succeeded(), eq(variables['SHOULD_PUBLISH'], 'false'))

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const dateTimeFormatter = new DateTimeFormatter(locale: string | ILocaleInfo);
 ```typescript
 type ILocaleInfo = {
   // Supported platform
-  platform: 'windows' | 'macos';
+  platform: "windows" | "macos";
 
   // OS date & time format settings (see below for OS support)
   regionalFormat: string; // e.g.: 'en-US'
@@ -51,7 +51,7 @@ provided! Most likely this will happen if you feed it the OS strings verbatim an
 the OS is configured with a custom date/time format string. If you don't desire
 this behavior, you can choose your own fallback (and telemetry) by wrapping the
 call to Globe and redoing it without OS-honoring support in case it fails with
-the *Unexpected format string* error.
+the _Unexpected format string_ error.
 
 ### OS Support
 
@@ -69,7 +69,7 @@ pattern:
   wraps the `window.getLocaleInfoAsync` function for you:
 
 ```typescript
-import { getLocaleInfoAsync } from '@microsoft/globe';
+import { getLocaleInfoAsync } from "@microsoft/globe";
 // Provide the supported platform name and obtain the OS locale settings
 const localeInfo = await getLocaleInfoAsync(/* 'windows` | 'macos' */);
 new DateTimeFormatter(localeInfo);
@@ -122,67 +122,99 @@ Build the package first: `npm run build`.
 There is a [GitHub Actions workflow](.github/workflows/main.yml) which runs the
 tests on every push to any branch.
 
-## GitHub Release Publishing
-
-GitHub Releases are made manually by @TomasHubelbauer at the moment.
-
 ## NPM Release Publishing
 
-Don't forget to build prior to cutting a release!
+NPM releases are automated through Azure DevOps pipeline.
 
-```sh
-# --tag=next pro pre-release (also include a pre-release tag in the version code)
-npm publish [--tag=next]
-# @microsoft/globe
-```
+### Standard Release Process
 
-Install the pre-release package using: `npm i @microsoft/globe@next`
+1. **Create a change file:**
 
-NPM Releases are made manually by @TomasHubelbauer at the moment.
+   ```sh
+   yarn change
+   ```
+
+   This creates a change file in the `/change` directory documenting your changes.
+
+2. **Bump the version:**
+
+   ```sh
+   yarn bump
+   ```
+
+   This uses Beachball to update the version in `package.json` and generate the changelog.
+
+3. **Commit and push:**
+
+   ```sh
+   git add .
+   git commit -m "Release: Bump version to x.x.x"
+   git push origin master
+   ```
+
+4. **Automatic publishing:**
+   - The Azure DevOps pipeline detects the version change
+   - Builds, signs, and publishes the package to npm automatically
+   - Only publishes if the version has been bumped
 
 ## Release Notes
 
 ### `4.1.4` 2024-02-14
+
 Add new format `MEDIUM_DATE_SHORT_TIME`
 
 ### `4.1.3` 2021-08-09
+
 Attempting to fix VDI issues on Electron
+
 ### `4.1.2` 2021-03-31
+
 Fixed 12 hours format for Windows
 
 ### `4.1.1` 2021-02-18
+
 Use for loops in an attempt to reduce memory consumption
 
 ### `4.1.0` 2021-02-03
+
 Use reducers in an attempt to reduce memory consumption (eliminate anonymous functions)
 Better checks for cases where time zone is not provided by default
 
 ### `4.0.0` 2020-11-10
+
 Use `hourCycle` for mac as it is supported in Electron 8
 
 ### `3.5.0` 2020-10-29
+
 Mac full date format
 
 ### `3.4.0` 2020-10-29
+
 Support quotes in format
 Support K and k tokens for mac
 
 ### `3.3.0` 2020-10-057
+
 Removed `SHORT_DATE_TIME_NO_YEAR`
 
 ### `3.2.0` 2020-10-05
+
 Add new format `SHORT_DATE_TIME_NO_YEAR`
 
 ### `3.1.0` 2020-09-08
+
 Add getLocaleInfoAsync to module export
 
 ### `3.0.1` 2020-09-04
+
 Improve error logging for unknown formats
 
 ### `3.0.0` 2020-07-22
+
 Avoid depending on Intl.DateTimeFormatParts which is not available in es5
 
 ### `2.8.1` 2020-07-20
+
 SafeDateTimeFormat with fallback to UTC if timezone is not detected or provided
 Use 0 instead of 24 for H and HH tokens
 
@@ -294,11 +326,6 @@ public consumption.
 
 Right now the tests are too rudimentary and are in JavaScript. Doing this will make it
 easier, faster and less error-prone to test the library.
-
-### Set up automated GitHub and NPM releases
-
-We don't cut releases too often, but this will still be useful to make the release
-process reproducible, reliable and consistent.
 
 ### Add more docs, especially around formatting based on OS date time settings
 


### PR DESCRIPTION
## Summary
Refactored the Azure DevOps release pipeline to include version detection that prevents unnecessary publishing when the package version hasn't changed, while providing an emergency bypass option for urgent releases.

## Changes Made

### 🔧 Pipeline Updates (.azure-devops/globe-release.yml)
- **Removed Automated Bumping**: Eliminated problematic beachball auto-bump that conflicted with branch protection rules
- **Version Detection**: Added git-based version comparison between current commit and parent commit
- **Conditional Publishing**: All signing and publishing steps now only run when version has actually changed
- **Emergency Override**: Added `skipVersionCheck` variable to bypass version detection for edge cases
- **Enhanced Logging**: Clear feedback showing version comparison results and publishing decisions

## Testing
- [x] Version detection script tested locally
- [x] Pipeline configuration validated
- [x] Documentation updated to match new workflow

## Usage
**Normal Release:**
1. `yarn change` - Create change file
2. `yarn bump` - Update version and changelog  
3. Commit and push - Pipeline auto-detects version change and publishes

**Edge Case Release:**
- Set `skipVersionCheck: true` in Azure DevOps pipeline variables