### PR TITLE
Version update

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -1,0 +1,20 @@
+{
+  "name": "@microsoft/globe",
+  "entries": [
+    {
+      "date": "Tue, 02 Sep 2025 11:46:06 GMT",
+      "version": "4.2.0",
+      "tag": "@microsoft/globe_v4.2.0",
+      "comments": {
+        "minor": [
+          {
+            "author": "liviudima@microsoft.com",
+            "package": "@microsoft/globe",
+            "commit": "48203adbdff2275e1423054a76aec9c91f4fd6c9",
+            "comment": "Updating dev depenencies and switch build to esm from cjs."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log - @microsoft/globe
+
+<!-- This log was last generated on Tue, 02 Sep 2025 11:46:06 GMT and should not be manually modified. -->
+
+<!-- Start content -->
+
+## 4.2.0
+
+Tue, 02 Sep 2025 11:46:06 GMT
+
+### Minor changes
+
+- Updating dev depenencies and switch build to esm from cjs. (liviudima@microsoft.com)

--- a/change/@microsoft-globe-8275cb61-311f-41ad-9d90-a837ad94760a.json
+++ b/change/@microsoft-globe-8275cb61-311f-41ad-9d90-a837ad94760a.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Updating dev depenencies and switch build to esm from cjs.",
-  "packageName": "@microsoft/globe",
-  "email": "liviudima@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/globe",
-  "version": "4.1.4",
+  "version": "4.2.0",
   "description": "Globalization Service",
   "author": "Microsoft",
   "license": "MIT",


### PR DESCRIPTION
This pull request publishes version 4.2.0 of the `@microsoft/globe` package, with a minor update focused on development dependencies and build configuration. The main change is updating dev dependencies and switching the build output from CommonJS (cjs) to ECMAScript Modules (esm).

Release and build changes:

* Bumped package version to `4.2.0` in `package.json` to reflect the new release.
* Added changelog entries documenting the update to dev dependencies and the switch to esm build in both `CHANGELOG.md` and `CHANGELOG.json`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R13) [[2]](diffhunk://#diff-759c9f5c1cfee8f7063fed95d8cd960e43dd91c1caa538fd2376bf2037ad43e3R1-R20)
* Removed the obsolete change file `change/@microsoft-globe-8275cb61-311f-41ad-9d90-a837ad94760a.json` since its contents have been incorporated into the changelog.