### PR TITLE
release: bump @microsoft/globe to 4.5.1

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@microsoft/globe",
   "entries": [
     {
+      "date": "Wed, 01 Jul 2026 08:06:39 GMT",
+      "version": "4.5.1",
+      "tag": "@microsoft/globe_v4.5.1",
+      "comments": {
+        "patch": [
+          {
+            "author": "ligia.e.popescu@gmail.com",
+            "package": "@microsoft/globe",
+            "commit": "not available",
+            "comment": "Update dev dependencies (vitest 4, rollup, vite, lodash, flatted) and fix Vitest 4.x Date mocks"
+          }
+        ]
+      }
+    },
+    {
       "date": "Tue, 02 Dec 2025 18:44:44 GMT",
       "version": "4.5.0",
       "tag": "@microsoft/globe_v4.5.0",

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -10,7 +10,7 @@
           {
             "author": "ligia.e.popescu@gmail.com",
             "package": "@microsoft/globe",
-            "commit": "not available",
+            "commit": "1ef28da886861f618b4aef487d451f63446c9bdc",
             "comment": "Update dev dependencies (vitest 4, rollup, vite, lodash, flatted) and fix Vitest 4.x Date mocks"
           }
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @microsoft/globe
 
-<!-- This log was last generated on Tue, 02 Dec 2025 18:44:44 GMT and should not be manually modified. -->
+<!-- This log was last generated on Wed, 01 Jul 2026 08:06:39 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 4.5.1
+
+Wed, 01 Jul 2026 08:06:39 GMT
+
+### Patches
+
+- Update dev dependencies (vitest 4, rollup, vite, lodash, flatted) and fix Vitest 4.x Date mocks (ligia.e.popescu@gmail.com)
 
 ## 4.5.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/globe",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "Globalization Service",
   "author": "Microsoft",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Release PR bumping `@microsoft/globe` from **4.5.0 → 4.5.1**, following the documented Globe release process (create change file → `yarn bump` → release PR → pipeline publishes to npm).

## Changes included since 4.5.0
All changes merged to `master` since the last release are dev-dependency / build-tooling updates (no runtime source changes), so this is a **patch** bump:

- Bump vitest 3.0.7 → 4.1.0 (#117)
- Fix: use function expressions for Date mocks in Vitest 4.x
- Bump lodash 4.17.23 → 4.18.1 (#116)
- Bump vite 6.4.1 → 6.4.2 (#115)
- Bump flatted 3.3.3 → 3.4.2 (#114)
- Bump rollup 4.34.9 → 4.59.0 (#112)

## What this PR does
- Adds a beachball change entry and runs `yarn bump`
- `package.json` version → `4.5.1`
- Regenerates `CHANGELOG.md` / `CHANGELOG.json`

Once merged, the release pipeline detects the version change and publishes to npm via ESRP.
