### PR TITLE
Route Yarn package resolution through the internal Azure Artifacts feed

### DIFF
--- a/.azure-devops/globe-release.yml
+++ b/.azure-devops/globe-release.yml
@@ -77,11 +77,21 @@ extends:
                   EOF
 
                   # Yarn v1 fetches the exact `resolved` URLs from yarn.lock regardless of registry
-                  # config, so rewrite the locked public URLs to the feed (build copy only).
-                  sed -i 's#https://registry.yarnpkg.com/#'"${FEED}"'#g' yarn.lock
+                  # config, so rewrite every locked public URL to the feed (build copy only).
+                  sed -i \
+                    -e 's#https://registry.yarnpkg.com/#'"${FEED}"'#g' \
+                    -e 's#https://registry.npmjs.org/#'"${FEED}"'#g' \
+                    yarn.lock
 
-                  echo "Remaining public registry refs in yarn.lock (expect 0):"
-                  grep -c 'registry.yarnpkg.com\|registry.npmjs.org' yarn.lock || true
+                  # Fail the build if any public registry reference survives, so we never
+                  # proceed to install against a public feed.
+                  REMAINING=$(grep -Ec 'registry\.yarnpkg\.com|registry\.npmjs\.org' yarn.lock || true)
+                  echo "Remaining public registry refs in yarn.lock: ${REMAINING}"
+                  if [ "${REMAINING}" -ne 0 ]; then
+                    echo "##vso[task.logissue type=error]yarn.lock still references public registries after rewrite."
+                    grep -En 'registry\.yarnpkg\.com|registry\.npmjs\.org' yarn.lock
+                    exit 1
+                  fi
                 displayName: "Redirect Yarn to Azure Artifacts feed (build-time only)"
 
               # 1b. Inject feed credentials into the build-time .npmrc.

--- a/.azure-devops/globe-release.yml
+++ b/.azure-devops/globe-release.yml
@@ -54,7 +54,43 @@ extends:
               # 1. Setup and build
               - checkout: self
                 persistCredentials: true # fix for beachball: https://github.com/microsoft/beachball/issues/674
-              - script: yarn
+
+              # 1a. Redirect package resolution to the Azure Artifacts feed for the BUILD ONLY.
+              #     globe is open-source: the committed .npmrc / yarn.lock intentionally stay on
+              #     the public registry so external `yarn install` keeps working. These files are
+              #     rewritten in the pipeline working copy only (never committed) so the build makes
+              #     zero connections to public package feeds
+              - script: |
+                  set -euo pipefail
+                  FEED="https://pkgs.dev.azure.com/DomoreexpGithub/Github_Pipelines/_packaging/github-npm-mirror/npm/registry/"
+
+                  # Build-time .npmrc pointing at the private feed (auth injected by npmAuthenticate below).
+                  cat > .npmrc <<EOF
+                  registry=${FEED}
+                  always-auth=true
+                  package-lock=false
+                  EOF
+
+                  # Build-time .yarnrc (Yarn Classic v1) pinning the same feed registry.
+                  cat > .yarnrc <<EOF
+                  registry "${FEED}"
+                  EOF
+
+                  # Yarn v1 fetches the exact `resolved` URLs from yarn.lock regardless of registry
+                  # config, so rewrite the locked public URLs to the feed (build copy only).
+                  sed -i 's#https://registry.yarnpkg.com/#'"${FEED}"'#g' yarn.lock
+
+                  echo "Remaining public registry refs in yarn.lock (expect 0):"
+                  grep -c 'registry.yarnpkg.com\|registry.npmjs.org' yarn.lock || true
+                displayName: "Redirect Yarn to Azure Artifacts feed (build-time only)"
+
+              # 1b. Inject feed credentials into the build-time .npmrc.
+              - task: npmAuthenticate@0
+                displayName: "Authenticate to Azure Artifacts feed"
+                inputs:
+                  workingFile: .npmrc
+
+              - script: yarn install --frozen-lockfile
                 displayName: "yarn"
               - script: |
                   yarn ci


### PR DESCRIPTION
## Summary

Updates the `globe-release` pipeline to resolve all Yarn packages through the internal Azure Artifacts feed **`github-npm-mirror`** instead of the public package endpoints (`registry.yarnpkg.com`, `registry.npmjs.org`). The feed is applied at build time only.

## Key constraint: globe is open-source

The private feed (`pkgs.dev.azure.com/DomoreexpGithub/...`) requires org auth that external contributors don't have. If it were committed into `.npmrc` / `yarn.lock`, every public `yarn install` would fail with `401`.

**Strategy — build-time injection:** the committed `.npmrc` and `yarn.lock` **intentionally stay on the public registry** so external installs keep working. Redirection to the feed happens **only inside the pipeline working copy** and is never committed.

## Background

- Repo uses **Yarn Classic v1** (lockfile v1). Yarn v1 fetches the exact `resolved` URLs from `yarn.lock` directly, regardless of `.npmrc`/`.yarnrc` registry config.
- `yarn.lock` contains **438** `resolved "https://registry.yarnpkg.com/..."` URLs.
- The pipeline previously ran a bare `- script: yarn` (install) with no feed authentication or redirection.

## Changes (`.azure-devops/globe-release.yml`, before the install step)

1. **Redirect step (build-time only):** writes a build-time `.npmrc` (feed registry + `always-auth=true`) and `.yarnrc` (`registry "<feed>"`), then `sed`-rewrites all 438 `registry.yarnpkg.com` URLs in `yarn.lock` → the feed.
2. **`npmAuthenticate@0`** on the build-time `.npmrc` — injects feed credentials.
3. Install changed to **`yarn install --frozen-lockfile`**.

`.yarnrc.yml`/`npmRegistryServer` is a **Yarn Berry** concept and is ignored by Yarn v1, so `.yarnrc` + `.npmrc` are used instead.

## Verification

- ✅ Pipeline YAML parses; script heredocs dedent correctly.
- ✅ `sed` dry-run on the real `yarn.lock` → **0** public refs, **438** feed refs, tarball paths intact. Integrity hashes unchanged (the feed mirrors identical tarballs), so `--frozen-lockfile` stays valid.
- ✅ `git diff` touches **only** the pipeline file; committed `.npmrc`/`yarn.lock` remain on public URLs.
- ✅ `package.json` audited clean: no `publishConfig.registry`, no public URLs in `resolutions`, no tarball deps, no `--registry` flags in scripts.

## Follow-up actions (external — outside this repo)

- [ ] Ensure the pipeline build identity (or a service connection) has **read** access to the `github-npm-mirror` feed.
- [ ] Onboard the pipeline to the **CFSClean** network isolation policy in Azure DevOps.
- [ ] Run the pipeline. The tracking item auto-resolves after zero public connections + **≥3 clean runs in a 7-day window**. If the pipeline isn't run or is deleted, contact netiso@microsoft.com.
