### PR TITLE
Onboard release pipeline to CFSClean network isolation policy

### DIFF
--- a/.azure-devops/globe-release.yml
+++ b/.azure-devops/globe-release.yml
@@ -20,11 +20,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
 
   parameters:
-    # Network isolation: block connections to public package endpoints so the build
-    # resolves only from the internal Azure Artifacts feed. CFSClean blocks the public
-    # Yarn/npm endpoints (registry.yarnpkg.com, registry.npmjs.org). Permissive and
-    # CFSClean2 are the policies already applied to this pipeline and MUST be kept —
-    # specifying a CFSClean* policy alone would block ALL connections.
+    # Keep existing policies (a CFSClean* policy alone blocks all traffic); CFSClean blocks public Yarn/npm endpoints.
     settings:
       networkIsolationPolicy: Permissive,CFSClean2,CFSClean
     sdl:

--- a/.azure-devops/globe-release.yml
+++ b/.azure-devops/globe-release.yml
@@ -20,6 +20,13 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
 
   parameters:
+    # Network isolation: block connections to public package endpoints so the build
+    # resolves only from the internal Azure Artifacts feed. CFSClean blocks the public
+    # Yarn/npm endpoints (registry.yarnpkg.com, registry.npmjs.org). Permissive and
+    # CFSClean2 are the policies already applied to this pipeline and MUST be kept —
+    # specifying a CFSClean* policy alone would block ALL connections.
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean2,CFSClean
     sdl:
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared


### PR DESCRIPTION
## Summary

Onboards the `globe-release` pipeline to the **CFSClean** network isolation policy so that connections to public package endpoints are blocked at the platform level — preventing any future regression back to the public Yarn/npm registries.

This is the follow-up "prevent future connections" step to the feed-redirect change: once package resolution goes through the internal Azure Artifacts feed, CFSClean guarantees the build can no longer reach `registry.yarnpkg.com` / `registry.npmjs.org`.

## Change (`.azure-devops/globe-release.yml`)

Adds the 1ES Pipeline Template setting:

```yaml
extends:
  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
  parameters:
    settings:
      networkIsolationPolicy: Permissive,CFSClean2,CFSClean
```

## Why these policies

The "Start Network Isolation" task in the current release build reports two policies already applied:

| Policy | Source | Notes |
| --- | --- | --- |
| `Permissive` | PerPipelineConfig | Least-secure baseline; allows most internet traffic |
| `CFSClean2` | PerPipelineRequiredConfig | Blocks wave-2 public package endpoints |

The public Yarn/npm endpoints are blocked by the base **CFSClean** policy, which is **not** currently applied — so it is appended. Both existing policies (`Permissive`, `CFSClean2`) are **kept**, specifying a `CFSClean*` policy alone would block **all** connections during the build.

## Verification

- ✅ Pipeline YAML parses; `settings` sits alongside `sdl`/`stages` under `parameters`.
- After merge, confirm the next run's **"Start Network Isolation"** task lists `Permissive`, `CFSClean2`, and `CFSClean`.

## Related

Follow-up to the feed-redirect PR (#119). Together these achieve zero public package-feed connections;
